### PR TITLE
Add SNS Publish Permission for Lambda

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -55,6 +55,9 @@ Resources:
       Timeout: 5
       CodeUri: ./index.js
       Runtime: nodejs6.10
+      Policies:
+        - SNSPublishMessagePolicy:
+            TopicName: !GetAtt ContactUsSNSTopic.TopicName
       Events:
         PostEvent:
           Type: Api


### PR DESCRIPTION
Uses SAM policy templates to allow publish permissions to the SNS topic.